### PR TITLE
fixed gpu.jl include if CUDA is non functional

### DIFF
--- a/src/PrimitiveOneHot.jl
+++ b/src/PrimitiveOneHot.jl
@@ -11,7 +11,7 @@ include("primitive.jl")
 include("array.jl")
 
 @init @require CUDA="052768ef-5323-5732-b1bb-66c8b64840ba" begin
-    include("gpu.jl")
+    CUDA.functional() && include("gpu.jl")
 end
 
 include("op.jl")


### PR DESCRIPTION
The fix prevents wrong behavior if CUDA package is included somewhere but there are no actual CUDA drivers on the local machine. That might be happening e.g. when Transformers.jl has been included before PrimitiveOneHot as the Transformers includes CUDA internally.

```
julia> using CUDA
julia> using PrimitiveOneHot
WARNING: method definition for CuArray at julia/PrimitiveOneHot.jl/src/gpu.jl:29 declares type variable A but does not use it.
WARNING: method definition for CuArray at julia/PrimitiveOneHot.jl/src/gpu.jl:29 declares type variable N+1 but does not use it.
WARNING: method definition for CuArray at julia/PrimitiveOneHot.jl/src/gpu.jl:29 declares type variable K but does not use it.
```